### PR TITLE
Dev

### DIFF
--- a/G30-project/MockData/MockData.swift
+++ b/G30-project/MockData/MockData.swift
@@ -1,1 +1,25 @@
+import Foundation
+
+extension CityWeather {
+    static let mockToronto = CityWeather(
+        city: "Toronto",
+        temperature: "19°",
+        condition: "Mostly Rainy",
+        highLow: "H: 24°  |  L: 18°",
+        hourly: [
+            .init(time: "12 AM", icon: "cloud.rain.fill", temp: "19°", precip: "30%"),
+            .init(time: "Now", icon: "cloud.rain.fill", temp: "19°", precip: "30%"),
+            .init(time: "2 AM", icon: "cloud.drizzle.fill", temp: "18°", precip: "25%"),
+            .init(time: "3 AM", icon: "cloud.rain.fill", temp: "19°", precip: "35%"),
+            .init(time: "4 AM", icon: "cloud.rain.fill", temp: "19°", precip: "40%"),
+            .init(time: "5 AM", icon: "cloud.bolt.rain.fill", temp: "19°", precip: "45%")
+        ],
+        factors: [
+            .init(title: "Heavy Rain", icon: "cloud.rain.fill"),
+            .init(title: "Strong Winds", icon: "wind"),
+            .init(title: "Hail Possible", icon: "cloud.hail.fill")
+        ],
+        theme: .rainy
+    )
+}
 

--- a/G30-project/Models/CityWeather.swift
+++ b/G30-project/Models/CityWeather.swift
@@ -1,1 +1,9 @@
-
+struct CityWeather {
+    let city: String
+    let temperature: String
+    let condition: String
+    let highLow: String
+    let hourly: [HourlyForecast]
+    let factors: [StormFactor]
+    let theme: WeatherTheme
+}

--- a/G30-project/Models/HourlyForecast.swift
+++ b/G30-project/Models/HourlyForecast.swift
@@ -1,1 +1,9 @@
+import Foundation
 
+struct HourlyForecast: Identifiable {
+    let id = UUID()
+    let time: String
+    let icon: String
+    let temp: String
+    let precip: String
+}

--- a/G30-project/Models/StormFactor.swift
+++ b/G30-project/Models/StormFactor.swift
@@ -1,1 +1,7 @@
+import Foundation
 
+struct StormFactor: Identifiable {
+    let id = UUID()
+    let title: String
+    let icon: String
+}

--- a/G30-project/Theme/WeatherTheme.swift
+++ b/G30-project/Theme/WeatherTheme.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+enum WeatherTheme {
+    case rainy, cloudy, sunny, storm, snowy, windy, defaultTheme
+
+    var gradient: [Color] {
+        switch self {
+        case .sunny:
+            return [Color.white, Color.yellow.opacity(0.05), Color.orange.opacity(0.35)] 
+        case .cloudy:
+            return [Color.white, Color.gray.opacity(0.25), Color.gray.opacity(0.35)]
+        case .rainy:
+            return [Color.white, Color.blue.opacity(0.05), Color.blue.opacity(0.35)]
+        case .storm:
+            return [Color.white, Color.blue.opacity(0.05), Color.black.opacity(0.90)]
+        case .snowy:
+            return [Color.white, Color.cyan.opacity(0.25), Color.blue.opacity(0.50)]
+        case .windy:
+            return [Color.white, Color.mint.opacity(0.08), Color.gray.opacity(0.65)]
+        case .defaultTheme:
+            return [Color.white, Color.gray.opacity(0.15), Color.blue.opacity(0.55)]
+        }
+    }
+}

--- a/G30-project/Views/CityDeepDive/CityDeepDive.swift
+++ b/G30-project/Views/CityDeepDive/CityDeepDive.swift
@@ -1,1 +1,137 @@
+import SwiftUI
 
+struct CityDeepDive: View {
+    let data: CityWeather
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: data.theme.gradient,
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 18) {
+                    headerCard
+                    hourlyRow
+                    riskFactors
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+                .padding(.bottom, 30)
+            }
+        }
+        .navigationTitle(data.city)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+
+    private var headerCard: some View {
+        VStack(spacing: 6) {
+            Text(data.city)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.black.opacity(0.65))
+
+            Text(data.condition)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.black.opacity(0.45))
+
+            Text(data.temperature)
+                .font(.system(size: 74, weight: .thin))
+                .foregroundStyle(.black.opacity(0.80))
+                .monospacedDigit()
+
+            Text(data.highLow)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.black.opacity(0.45))
+        }
+        .padding(.top, 8)
+    }
+
+    private var hourlyRow: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Hourly")
+                .font(.headline)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(data.hourly) { item in
+                        HourChip(item: item)
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var riskFactors: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Storm Risk Factors")
+                .font(.headline)
+
+            VStack(spacing: 10) {
+                ForEach(data.factors) { f in
+                    HStack(spacing: 12) {
+                        Image(systemName: f.icon)
+                            .font(.system(size: 20, weight: .semibold))
+                            .frame(width: 28)
+
+                        Text(f.title)
+                            .font(.system(size: 16, weight: .semibold))
+
+                        Spacer()
+                    }
+                    .padding(14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color(.secondarySystemGroupedBackground))
+                    )
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct HourChip: View {
+    let item: HourlyForecast
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(item.time)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Image(systemName: item.icon)
+                .font(.system(size: 18, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+
+            Text(item.temp)
+                .font(.system(size: 16, weight: .semibold))
+                .monospacedDigit()
+
+            Text(item.precip)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .frame(width: 74, height: 110)
+        .background(
+            RoundedRectangle(cornerRadius: 40, style: .continuous)
+                .fill(Color.gray.opacity(0.18))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 40, style: .continuous)
+                        .stroke(Color.white.opacity(0.25), lineWidth: 1)
+                )
+        )
+
+    }
+}
+
+#Preview {
+    NavigationStack {
+        CityDeepDive(data: .mockToronto)
+    }
+}

--- a/G30-project/Views/Dashboard/DashboardView.swift
+++ b/G30-project/Views/Dashboard/DashboardView.swift
@@ -7,6 +7,11 @@ struct DashboardView: View{
                 .font(.title2).bold()
             Text("Multi-city list")
                 .foregroundStyle(.secondary)
+            NavigationLink {
+                CityDeepDive(data: .mockToronto)
+            } label: {
+                Text("Toronto")
+            }
         }
         .navigationTitle("Weather")
     }


### PR DESCRIPTION
This PR adds the initial project skeleton + my City Deep Dive screen.

Changes made:

* Organized the project into folders so we can work in parallel:

  * Views/Dashboard/ (dashboard screen work goes here)
  * Views/Map/ (map screen work goes here)
  * Views/Notifications/ (notification history screen work goes here)
  * Views/CityDeepDive/ (city details screen, implemented here)
  * Models/ (shared structs)
  * MockData/ (seeded data for UI testing)
  * Theme/ (shared styling logic, for now)
  * Navigation/ (tab/navigation structure)

City Deep Dive:

* Implemented CityDeepDive UI with gradient background so its not ugly
* Uses seeded mock data from MockData

WeatherTheme:

* Added WeatherTheme to control screen background based on weather type, we can update that later
* Right now theme is set in mock data
* Later we’ll map API weather condition -> WeatherTheme so the UI updates automatically per city
